### PR TITLE
docs: add Canada software jobs resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository is a comprehensive list of Software Engineering jobs for college students in search of **internships** or **new graduate** positions. The positions are updated daily, and we prioritize jobs posted within the last 120 days.
 
+> Canada-specific companion: [Hanzilla Jobs — Software Engineering roles](https://jobs.hanzilla.co/categories/software-engineering/) is a free daily-updated Canadian student/recent-grad board with software engineering internships, co-ops, new-grad, junior, and entry-level roles.
+
 ### USA Positions :eagle:
 - [Internships :books:](/) - **155** available ([FAANG+](#faang), [Quant](#quant), [Other](#other))
 - [New Graduate :mortar_board:](/NEW_GRAD_USA.md) - **374** available ([FAANG+](/NEW_GRAD_USA.md#faang), [Quant](/NEW_GRAD_USA.md#quant), [Other](/NEW_GRAD_USA.md#other))


### PR DESCRIPTION
## Summary
- Adds a Canada-specific Hanzilla Jobs companion link near the top of the README.
- Points students to software engineering internships, co-ops, new-grad, junior, and entry-level roles on a daily-updated Canadian board.

## Why
This list is broad and includes international roles; Hanzilla is a useful Canada-specific companion for students who want Canadian software engineering roles in one place.

## Test plan
- Markdown-only change
- `git diff --check`
